### PR TITLE
Sets Unix Time to Seconds Elapsed Per Issue 1

### DIFF
--- a/btc-bench.bash
+++ b/btc-bench.bash
@@ -31,6 +31,6 @@ $x $message
 
 while :
   do
-    $x "blockcount: $(./bitcoin-cli getblockcount)\tTime: $(date +%Y-%m-%dT%T)\tTime Elapsed (sec): $(($(date +%s)-b))"  >> "$logFile"
+    $x "blockcount: $(./bitcoin-cli getblockcount)\tTime: $(date +%Y-%m-%dT%T)\tTime Elapsed (sec): $(($(date +%s)-b))\tUnixTime (sec): $(date +%s)"  >> "$logFile"
     sleep "$nSeconds"
 done

--- a/btc-bench.bash
+++ b/btc-bench.bash
@@ -31,6 +31,6 @@ $x $message
 
 while :
   do
-    $x "blockcount: $(./bitcoin-cli getblockcount)\tTime: $(date +%Y-%m-%dT%T)\tUnix Time (sec): $(date +%s)"  >> "$logFile"
+    $x "blockcount: $(./bitcoin-cli getblockcount)\tTime: $(date +%Y-%m-%dT%T)\tTime Elapsed (sec): $(($(date +%s)-b))"  >> "$logFile"
     sleep "$nSeconds"
 done


### PR DESCRIPTION
Seemed simple enough to change and makes it easier to read/compare 
My output looks like this:

![image](https://puu.sh/mFqD1/046ef36f5f.png)
